### PR TITLE
Fix: Messages with no headers crash the router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## 0.1.1
+
+### Fix
+
+* Stop the router crashing a message has no headers. [Ben Dalling]
+
+
 ## 0.1.1 (2024-08-04)
 
 ### New

--- a/router.py
+++ b/router.py
@@ -158,15 +158,12 @@ class KafkaRouterRule:
         """
         raw_message = message.value().decode('utf-8')
 
-        if self.regexp and not self.jmespath:
-            return raw_message
-
         if self.jmespath:
             data = json.loads(raw_message)
             logger.debug(f'JMESPath is looking for "{self.jmespath}" in "{data}".')
             return jmespath.search(self.jmespath, data)
 
-        return None
+        return raw_message
 
     def match_message(self, message: Message) -> bool:
         """
@@ -210,12 +207,15 @@ class KafkaRouter:
 
     def __init__(self, DLQ_topic_name: str = None) -> None:
         env_config = EnvironmentConfig()
+        self._headers = []
         self.consumer_conf = env_config.get_config('KAFKA_CONSUMER_')
         self.producer_conf = env_config.get_config('KAFKA_PRODUCER_')
         self.DLQ_topic_name = DLQ_topic_name
         self.source_topics = []
         self.rules = []
         self.get_rules()
+        signal.signal(signal.SIGINT, self.handler)
+        signal.signal(signal.SIGTERM, self.handler)
 
     def add_rule(self, rule: KafkaRouterRule) -> None:
         """
@@ -432,8 +432,6 @@ class KafkaRouter:
         self.validate_consumer_config(self.consumer_conf)
         consumer = Consumer(self.consumer_conf)
         producer = Producer(self.producer_conf)
-        signal.signal(signal.SIGINT, self.handler)
-        signal.signal(signal.SIGTERM, self.handler)
 
         try:
             consumer.subscribe(self.source_topics)

--- a/tests/features/kafka-router-rule.feature
+++ b/tests/features/kafka-router-rule.feature
@@ -15,6 +15,9 @@ Feature: Kafka Router Rule
         | { "given_name": "John", "family_name": "Smith", "company_name": "John Smith & Associates" }                  | {"destination_topic":"GB.output","jmespath":"country","regexp":"^GB$","source_topic":"input"} | False            |
         | { "given_name": "John", "family_name": "Smith", "company_name": "John Smith & Associates", "country": "GB" } | {"destination_topic":"GB.output","jmespath":"country","regexp":"^GB$","source_topic":"input"} | True             |
         | { "given_name": "John", "family_name": "Smith", "company_name": "John Smith & Associates", "country": "GB" } | {"destination_topic":"GB.output","jmespath":"country","source_topic":"input"}                 | True             |
+        | Country: England                                                                                             | {"destination_topic":"GB.output","regexp":"Scotland","source_topic":"input"}                  | False            |
+        | Country: Scotland                                                                                            | {"destination_topic":"GB.output","regexp":"Scotland","source_topic":"input"}                  | True             |
+        | Hello, world!                                                                                                | {"destination_topic":"GB.output","source_topic":"input"}                                      | True             |
 
     Scenario Outline: Rule Exceptions
         Given an Invalid Kafka Router Rule of <rule>

--- a/tests/features/kafka-router.feature
+++ b/tests/features/kafka-router.feature
@@ -28,6 +28,7 @@ Feature: The KafkaRouter class.
         When OS environment KAFKA_ROUTER_DLQ_ID is <kafka_router_dlq_id>
         And OS environment KAFKA_CONSUMER_CLIENT_ID is <kafka_consumer_client_id>
         And OS environment KAFKA_CONSUMER_GROUP_ID is <kafka_consumer_group_id>
+        And OS environment KAFKA_ROUTER_RULE_1 is {"destination_topic":"output","source_topic":"input"}
         Then DLQ ID is <expected_value>
 
         Examples:
@@ -37,7 +38,18 @@ Feature: The KafkaRouter class.
             | None      | None                | None                     | c                       | c              |
 
     Scenario: Test Upsert Headers
-        Given  a KafkaRouter with DLQ topic None
+        Given a KafkaRouter with DLQ topic None
         And populated headers
         When new headers are appended
         Then headers count is two
+
+    Scenario Outline: Test Signal Handler
+        Given a KafkaRouter with DLQ topic None
+        And System Signal is <signal>
+        When System Signal is sent
+        Then KafkaRouter handler catches it
+
+        Examples:
+            | signal  |
+            | SIGINT  |
+            | SIGTERM |

--- a/tests/features/system.feature
+++ b/tests/features/system.feature
@@ -64,10 +64,10 @@ Feature: System Tests
 
         Examples:
         | expected_output                                   |
-        | docker_consumer_message_count_total 7.0           |
-        | docker_consumer_message_committed_count_total 7.0 |
-        | docker_producer_message_count_total 7.0           |
-        | docker_non_routed_error_count_total 3.0           |
+        | docker_consumer_message_count_total 8.0           |
+        | docker_consumer_message_committed_count_total 8.0 |
+        | docker_producer_message_count_total 8.0           |
+        | docker_non_routed_error_count_total 4.0           |
 
     Scenario Outline: Track Test Message Destinations
         Given a Kafka Consumer Config

--- a/tests/features/system.feature
+++ b/tests/features/system.feature
@@ -86,6 +86,7 @@ Feature: System Tests
         | test        | TEST01D      | GB.output.json |
         | test        | TEST01E      | IE.output.json |
         | test        | TEST01F      | IE.output.json |
+        | test        | TEST02A      | router.dlq     |
 
     Scenario: Stop The Router Container
         Given the TestInfra host with URL "local://" is ready

--- a/tests/resources/init/init.sh
+++ b/tests/resources/init/init.sh
@@ -5,3 +5,6 @@ kafka-topics --bootstrap-server kafka:29092 --create --topic router.dlq --if-not
 kafka-topics --bootstrap-server kafka:29092 --create --topic IE.output.json --if-not-exists
 kafka-topics --bootstrap-server kafka:29092 --create --topic GB.output.json --if-not-exists
 kafka-topics --bootstrap-server kafka:29092 --list
+
+# We add this message with no messages as a test for bug #28.
+echo 'Plain text message with no header.' | kafka-console-producer --bootstrap-server kafka:29092 --topic input.json


### PR DESCRIPTION
This PR:
- Fixes #28 
- Does some refactoring of the tests.